### PR TITLE
Add README with usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Zyxel Toolkit
+
+This toolkit contains a collection of Python scripts for interacting with Zyxel modems. Tools allow you to log in to a modem, fetch and decrypt configuration data, edit accounts and log settings, upload TR069 data and more. The `scripts/` directory provides standalone utilities while common functionality lives under `src/`.
+
+## Setup
+1. Ensure Python 3.11 or later is installed.
+2. Install the required packages:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+The scripts rely on Selenium for browser automation and Cryptodome for AES operations.
+
+## Running the Toolkit
+All utilities can be launched through the command line interface:
+
+```bash
+python scripts/cli.py
+```
+
+The CLI lists available scripts and runs the selected one with the correct `PYTHONPATH` so modules in `src/` are found.
+
+## Credentials
+Scripts that log in to the modem expect credentials to be provided through environment variables:
+
+- `MODEM_USERNAME` – username for the admin interface
+- `MODEM_PASSWORD` – password for the admin interface
+
+Set these variables in your shell before running the CLI so the login process can pick them up.


### PR DESCRIPTION
## Summary
- add a README describing the toolkit
- explain setup, requirements installation and running `scripts/cli.py`
- document environment variables for modem credentials

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68880651ba74832d8e4db2d06de32d92